### PR TITLE
feat: move to `ratatui` instead of `tui`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-utils"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,5 +10,4 @@ anyhow = "1.0.66"
 crossterm = { version ="0.25.0", features = ["serde"] }
 serde = { version = "1.0.147", features = ["derive", "rc"] }
 thiserror = "1.0.37"
-tui = "0.19.0"
 shared_derive = { path = "shared_derive"}

--- a/examples/bounded_state.rs
+++ b/examples/bounded_state.rs
@@ -1,10 +1,12 @@
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-use std::error::Error;
-use tui::{
+use ratatui::{
+    backend::Backend,
     layout::Rect,
     style::Color,
     widgets::{Clear, List, ListItem},
+    Frame,
 };
+use std::error::Error;
 use tui_utils::{
     blocks,
     component::Component,
@@ -73,7 +75,7 @@ struct View {
 
 impl Component for View {
     type Message = AppMessage;
-    fn draw<B: tui::backend::Backend>(&mut self, f: &mut tui::Frame<B>, _dim: bool) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, _dim: bool) {
         // get the size of the frame
         let size = f.size();
 

--- a/examples/focus_delegation.rs
+++ b/examples/focus_delegation.rs
@@ -9,8 +9,10 @@ use std::{error::Error, rc::Rc};
 use tui_utils::{
     blocks::{self, Dim},
     component::Component,
-    keys::{key_match, Keybind, Shared},
-    rect, term,
+    keys::{key_match, Keybind},
+    rect,
+    shared::Shared,
+    term,
 };
 
 // Example of how to define keybinds.
@@ -69,8 +71,8 @@ struct Modal {
 
 impl Component for Main {
     type Message = AppMessage;
-    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, dim: bool) {
-        let p = Paragraph::new("This is the main component")
+    fn draw<B: tui::backend::Backend>(&mut self, f: &mut tui::Frame<B>, dim: bool) {
+        let p = Paragraph::new("This is the main component. Press space to open modal.")
             .block(blocks::default_block("Main", Color::White).dim(dim));
         f.render_widget(p, f.size());
     }

--- a/examples/focus_delegation.rs
+++ b/examples/focus_delegation.rs
@@ -1,9 +1,11 @@
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-use std::{error::Error, rc::Rc};
-use tui::{
+use ratatui::{
+    backend::Backend,
     style::Color,
     widgets::{Clear, Paragraph},
+    Frame,
 };
+use std::{error::Error, rc::Rc};
 use tui_utils::{
     blocks::{self, Dim},
     component::Component,
@@ -67,7 +69,7 @@ struct Modal {
 
 impl Component for Main {
     type Message = AppMessage;
-    fn draw<B: tui::backend::Backend>(&mut self, f: &mut tui::Frame<B>, dim: bool) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, dim: bool) {
         let p = Paragraph::new("This is the main component")
             .block(blocks::default_block("Main", Color::White).dim(dim));
         f.render_widget(p, f.size());
@@ -87,7 +89,7 @@ impl Component for Main {
 
 impl Component for Modal {
     type Message = AppMessage;
-    fn draw<B: tui::backend::Backend>(&mut self, f: &mut tui::Frame<B>, _dim: bool) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, _dim: bool) {
         let rect = rect::centered_rect(f.size());
         let p =
             Paragraph::new("This is the modal").block(blocks::default_block("Modal", Color::White));

--- a/examples/split_view.rs
+++ b/examples/split_view.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{backend::Backend, style::Color, widgets::Paragraph, Frame};
 use std::error::Error;
-use tui::{style::Color, widgets::Paragraph};
 use tui_utils::{
     blocks,
     component::Component,
@@ -46,7 +46,7 @@ struct Split {
 
 impl Component for Split {
     type Message = AppMessage;
-    fn draw<B: tui::backend::Backend>(&mut self, f: &mut tui::Frame<B>, _dim: bool) {
+    fn draw<B: Backend>(&mut self, f: &mut Frame<B>, _dim: bool) {
         // define a new ratio of 50/50
         let ratio = Ratio::new(50, 50);
         // create a vertical split using the frame size and ratio

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Borders},
 };

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crossterm::event::KeyEvent;
-use tui::{backend::Backend, Frame};
+use ratatui::{backend::Backend, Frame};
 
 /// Trait for implementing components
 pub trait Component {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,4 +1,4 @@
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 /// Produces a centered rect half the size of the width as well as the height.
 pub fn centered_rect(size: Rect) -> Rect {

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,4 +1,6 @@
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use std::rc::Rc;
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 /// Set the percentage ratio for the split
 #[derive(Debug)]
@@ -38,16 +40,16 @@ impl Ratio {
 }
 
 /// Generate a vertically split layout in a rect with a defined ratio
-pub fn v_split(rect: Rect, ratio: Ratio) -> Vec<Rect> {
+pub fn v_split(rect: Rect, ratio: Ratio) -> Rc<[Rect]> {
     construct_split(rect, ratio, Direction::Horizontal)
 }
 
 /// Generate a horizontally split layout in a rect with a defined ratio
-pub fn h_split(rect: Rect, ratio: Ratio) -> Vec<Rect> {
+pub fn h_split(rect: Rect, ratio: Ratio) -> Rc<[Rect]> {
     construct_split(rect, ratio, Direction::Vertical)
 }
 
-fn construct_split(re: Rect, ra: Ratio, d: Direction) -> Vec<Rect> {
+fn construct_split(re: Rect, ra: Ratio, d: Direction) -> Rc<[Rect]> {
     Layout::default()
         .direction(d)
         .constraints([Constraint::Percentage(ra.0), Constraint::Percentage(ra.1)].as_ref())

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
+use ratatui::widgets::ListState;
 use thiserror::Error;
-use tui::widgets::ListState;
 
 #[derive(Error, Debug)]
 pub enum StateError {

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-use tui::style::{Color, Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 
 /// Simple highlight style to be used with stateful widgets
 pub fn highlight_style() -> Style {

--- a/src/term.rs
+++ b/src/term.rs
@@ -3,11 +3,11 @@ use crossterm::event::{self, Event};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
 use std::error::Error;
 use std::io;
 use thiserror::Error;
-use tui::backend::CrosstermBackend;
-use tui::Terminal;
 
 #[derive(Error, Debug)]
 pub enum TermError {


### PR DESCRIPTION
Since `tui` is not currently being actively maintained, I have decided to move over to the community fork `ratatui` for all TUI related things in this library :)